### PR TITLE
Adicionado serviço para habilitar o firewall no boot do sistema.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -2,11 +2,9 @@
 set -e
 . /usr/share/debconf/confmodule
 
-if ! grep -q "habilita-firewall" /etc/rc.local; then
-  sed -i '/^exit 0/i \
-bash \/usr\/sbin\/habilita-firewall' /etc/rc.local
-fi
-
+# Habilitando o serviço do maratona-firewall para ser executado no boot do
+# sistema.
+systemctl enable maratona-firewall.service
 
 priority=medium
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,10 @@
 #! /usr/bin/make -f
 
 override_dh_auto_install:
+	# Serviço para habilitar o firewall no reboot via systemd
+	mkdir -p debian/maratona-firewall/lib/systemd/system/
+	cp service/maratona-firewall.service debian/maratona-firewall/lib/systemd/system/
+
 	mkdir -p debian/maratona-firewall/usr/sbin/
 	cp scripts-administrativos/config-ip-boca.sh debian/maratona-firewall/usr/sbin/config-ip-boca
 	chmod a+x debian/maratona-firewall/usr/sbin/config-ip-boca

--- a/service/maratona-firewall.service
+++ b/service/maratona-firewall.service
@@ -1,0 +1,15 @@
+# "Daemon" do maratona-firewall para ser executado na
+# inicialização do sistema. Esse deamon faz com que o firewall da máquina sempre
+# inicie ativado, cabendo ao administrador da máquina desativa-lo.
+
+[Unit]
+Description=Maratona Firewall Daemon
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/sbin/habilita-firewall
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
debian/rules: Adicionado o arquivo de serviço para executar o habilita-firewall
no boot do sistema.

debian/postinst: Substituido o "/etc/rc.local" pelo o sistemd. Na qual, nesse
script será habilitado o serviço que executa o script que habilita o firewall da
máquina do competidor ao iniciar a máquina.

service/maratona-firewall.service: Adicionado o arquivo de descrição do serviço.
Na qual é um serviço que executa como root, na qual possui o nome de Maratona
Firewall Daemon. Esse serviço é executado na inicialização do sistema.

Signed-off-by: Wall Berg Morais <wallbergmirandamorais@gmail.com>