### PR TITLE
Release version 20210517.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+maratona-firewall (20210517.1) focal; urgency=medium
+
+  [ Bruno Cesar Ribas ]
+  * maratona-firewall.service: Added RemainAfterExit directive
+  * Add support for special UFW rules
+
+  [ Davi Antônio da Silva Santos ]
+  * Update maintainer, description and dependencies
+  * Enable prerm script to exit on failure
+  * Update machine-readable copyright file
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Mon, 28 Jun 2021 20:52:19 -0300
+
 maratona-firewall (20210517) focal; urgency=medium
 
   [ Bruno Cesar Ribas ]

--- a/debian/control
+++ b/debian/control
@@ -1,13 +1,15 @@
 Source: maratona-firewall
 Section: misc
 Priority: optional
-Maintainer: Bruno Ribas <brunoribas@utfpr.edu.br>
+Maintainer: Bruno César Ribas <bruno.ribas@unb.br>
 Build-Depends: debhelper-compat (= 12)
+Vcs-Git: https://github.com/maratona-linux/maratona-firewall.git
+Vcs-Browser: https://github.com/maratona-linux/maratona-firewall
 
 Package: maratona-firewall
 Architecture: all
-Depends: ufw
-Description: Pacote que isola o competidor da rede.
+Depends: ufw, debconf
+Description: Pacote que isola o competidor da rede
  Este pacote evita que pacotes de rede entrem e saiam do maratona-linux,
  exceto pelo acesso ao servidor BOCA.
  .

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,14 +1,11 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: maratona-background
-Source: <url://example.com>
+Upstream-Name: maratona-firewall
+Source: <https://github.com/maratona-linux/maratona-firewall>
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2.0+
-
-Files: debian/*
-Copyright: 2016 Bruno Ribas <brunoribas@utfpr.edu.br>
+Copyright: 2016-2021 Bruno César Ribas <bruno.ribas@unb.br>
+           2021 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
+           2018 Wall Berg Morais <wallbergmirandamorais@gmail.com>
 License: GPL-2.0+
 
 License: GPL-2.0+
@@ -27,8 +24,3 @@ License: GPL-2.0+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -e
 
 systemctl disable maratona-firewall.service


### PR DESCRIPTION
Updates `debian/control` and `debian/changelog` in order to try to make the
package Lintian clean (issue #4).

- updates `debian/copyright`
- updates `debian/copyright`
- adds script abortion on failure (fixes Lintian
  maintainer-script-ignores-errors) on #4
- update maintainer's email and name
- fixes `missing-debconf-dependency` (Lintian)
- fixes `synopsis-is-a-sentence` (Lintian)
- adds repository details (Vcs-Browser and Vcs-Git)