### PR TITLE
Migrate package to Ubuntu jammy (22.04)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+maratona-firewall (20220517) jammy; urgency=medium
+
+  * Bump debhelper compat from 12 to 13
+  * Update copyright years
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Thu, 19 May 2022 12:09:16 -0300
+
 maratona-firewall (20210517.1) focal; urgency=medium
 
   [ Bruno Cesar Ribas ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+maratona-firewall (20230113) jammy; urgency=medium
+
+  * Update debian/copyright's years
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Fri, 13 Jan 2023 23:37:04 -0300
+
 maratona-firewall (20220517) jammy; urgency=medium
 
   * Bump debhelper compat from 12 to 13

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: maratona-firewall
 Section: misc
 Priority: optional
 Maintainer: Bruno César Ribas <bruno.ribas@unb.br>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 13)
 Vcs-Git: https://github.com/maratona-linux/maratona-firewall.git
 Vcs-Browser: https://github.com/maratona-linux/maratona-firewall
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,8 +3,8 @@ Upstream-Name: maratona-firewall
 Source: <https://github.com/maratona-linux/maratona-firewall>
 
 Files: *
-Copyright: 2016-2021 Bruno César Ribas <bruno.ribas@unb.br>
-           2021 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
+Copyright: 2016-2022 Bruno César Ribas <bruno.ribas@unb.br>
+           2021-2022 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
            2018 Wall Berg Morais <wallbergmirandamorais@gmail.com>
 License: GPL-2.0+
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Source: <https://github.com/maratona-linux/maratona-firewall>
 
 Files: *
 Copyright: 2016-2022 Bruno César Ribas <bruno.ribas@unb.br>
-           2021-2022 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
+           2021-2023 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
            2018 Wall Berg Morais <wallbergmirandamorais@gmail.com>
 License: GPL-2.0+
 


### PR DESCRIPTION
- migrate to Ubuntu 22.04 (jammy)
- release version 20230113 for the 27th Maratona de Programação finals in Campo Grande, Mato Grosso do Sul, Brazil